### PR TITLE
remove "mv" option for /cms/scratch due to lack of permission changer.

### DIFF
--- a/create-batch
+++ b/create-batch
@@ -132,10 +132,8 @@ class TheJobConfig():
             if self.dest.startswith('/store/'): self.dest = 'root://cms-xrdr.sdfarm.kr:1094///cms/data/xrd/%s' % self.dest
             if self.dest.startswith('root://'):
                 self.transferCmd = 'xrdcp '
-            elif self.dest.startswith('/cms/scratch/'):
-                self.transferCmd = 'mv '
             else:
-                self.transferCmd = "" ## Output file transfer to working directory is done by CONDOR
+                self.transferCmd = "" ## Output file transfer to working directory is done by CONDOR. /cms/scratch is not supporting now.
         else:
             ## Default transfer command by simple copy command
             self.transferCmd = "mv "


### PR DESCRIPTION
이상하게 잘 작동 안합니다. mv 옵션

HTCondor가 지원해주는 복사 옵션이 가장 좋을 거 같습니다.